### PR TITLE
removed colon from questions

### DIFF
--- a/client/src/app/components/view-project/view-project.component.html
+++ b/client/src/app/components/view-project/view-project.component.html
@@ -48,7 +48,7 @@
         <mat-card class="content-card">
           <mat-card-header>
             <mat-card-title>
-              <h2>Question {{ i + 1}}:</h2>
+              <h2>Question {{ i + 1}}</h2>
             </mat-card-title>
           </mat-card-header>
           <mat-card-content>
@@ -95,7 +95,7 @@
           <mat-card class="content-card">
             <mat-card-header>
               <mat-card-title>
-                <h2>{{projectData.questions[currentQuestionIndex].question}} :</h2>
+                <h2>{{projectData.questions[currentQuestionIndex].question}}</h2>
               </mat-card-title>
             </mat-card-header>
             <mat-card-content>


### PR DESCRIPTION
pr covers 2 tickets.

(View Project) Get rid of the colon after each question # (like Question 1:)

(View Project - Faculty) In Search by Questions, get rid of the Colon in the title (for all the question types)