### PR TITLE
Updated Packages' Liecensing 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },
+  "license": "UNLICENSED",
   "private": true,
   "dependencies": {
     "@angular/animations": "^19.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "web-portal-server",
+  "name": "server",
   "type": "module",
-  "version": "1.0.0",
-  "description": "",
+  "version": "0.0.0",
   "main": "server.js",
   "scripts": {
     "startServer": "node server.js",
@@ -10,8 +9,8 @@
     "debug": "nodemon --inspect server.js",
     "test": "cross-env NODE_ENV=test mocha unitTests/**/*.js --recursive --exit --timeout 10000"
   },
-  "author": "Sean Tierney",
-  "license": "ISC",
+  "license": "UNLICENSED",
+  "private": true,
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",


### PR DESCRIPTION
Updated package.json's to specify that the npm packages are private and unlicensed
- According to npm docs, this means [no one else has the rights to use the packages](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license) (this was already the case before, but now it's explicitly specified).